### PR TITLE
Resolve all File Types missing from Settings

### DIFF
--- a/src/main/groovy/com/github/camork/filesystem/ArchiveBasedFileType.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/ArchiveBasedFileType.groovy
@@ -14,7 +14,7 @@ abstract class ArchiveBasedFileType implements FileType {
 
     @Override
     String getDescription() {
-        null
+        getName() + " archive"
     }
 
     @Override


### PR DESCRIPTION
# Description

This PR alters the `ArchiveBasedFileType` base class to ensure `getDescription()` returns a non-null string.

`getDescription()` is used to sort the various FileTypes for display in the _Editor > File Types_ settings window; when a `null` is returned, the sorting throws a `NullPointerException` and all file types fail to display.


# The Hunt

A while back, I noticed the list of File Types in the Settings were missing. I'm not sure which version it started with, but I'm primarily using PyCharm 2019.2.1 (PY-192.6262.12) right now. This is what the File Types settings window looked like (mind, this image was taken while running under DevKit)
![missing-file-types](https://user-images.githubusercontent.com/33840/62968992-433b7100-bdda-11e9-89c5-fa956624f898.png)

In the IDEA log, I found this stacktrace
![idea-exception](https://user-images.githubusercontent.com/33840/62969030-58b09b00-bdda-11e9-8e08-1947c5fd01b5.png)

I traced back to the `FileTypeConfigurable.updateFileTypeList` method, and found this source
![updateFileTypeList-source](https://user-images.githubusercontent.com/33840/62969088-80076800-bdda-11e9-8d9b-0c09eb526f2a.png)

Figuring some FileType was returning `null` for `getDescription()`, I whipped up a little Groovy script using [LivePlugin](https://github.com/dkandalov/live-plugin) (super handy) to list all the FileTypes and their descriptions

```groovy
import static liveplugin.PluginUtil.*
import com.intellij.openapi.fileTypes.FileTypeRegistry
import com.intellij.openapi.fileTypes.FileType

fileTypeRegistry = FileTypeRegistry.getInstance()
registeredFileTypes = fileTypeRegistry.getRegisteredFileTypes()

for (FileType fileType : registeredFileTypes) {
    log(String.format("%s — %s", fileType.class, fileType.getDescription()))
}
```

The culprits were found ;)
![liveplugin-dump-of-filetypes](https://user-images.githubusercontent.com/33840/62969302-f60bcf00-bdda-11e9-87d1-d9c88e489837.png)

I added a basic little `getDescription()` based on `getName()`, and all is well in the world
![fixed-filetypes](https://user-images.githubusercontent.com/33840/62969692-d1642700-bddb-11e9-85d8-e74e0eb9e2c4.png)
