### PR TITLE
Support reading Gzip files with no filename metadata

### DIFF
--- a/src/main/groovy/com/github/camork/filesystem/gz/GZFile.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/gz/GZFile.groovy
@@ -44,10 +44,15 @@ class GZFile implements IArchiveFile {
         (inputStream as GzipCompressorInputStream).withCloseable {
             _innerName = it.metaData.filename
         }
-        Map entries = [:]
+
+        if (_innerName == null) {
+            int idx = _file.name.indexOf(CoreUtil.DOT + GZFileType.INSTANCE.defaultExtension)
+            _innerName = idx == -1 ? "contents" : _file.name.substring(0, idx)
+        }
 
         EntryInfo root = ArchiveUtils.createRootEntry()
 
+        Map entries = [:]
         entries.put('', root)
         entries.put(_innerName, new EntryInfo(_innerName, false, _file.length(), _file.lastModified(), root))
 


### PR DESCRIPTION
This is to close out issue #35 raised earlier. If the Gzip file doesn't contain a filename in the metadata, we are currently unable to open the contents for reading in the IDE. The following changes stubs out an entry in the info map using the original filename so that we can view the file contents.