### PR TITLE
Add support for viewing zstd compressed files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ configurations.testImplementation.extendsFrom(configurations.compileOnly)
 dependencies {
     compileOnly 'org.codehaus.groovy:groovy-all:3.0.13'
     compileOnly 'org.apache.commons:commons-compress:1.23.0'
+    implementation('com.github.luben:zstd-jni:1.5.5-9')
 }
 
 intellij {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ configurations.testImplementation.extendsFrom(configurations.compileOnly)
 dependencies {
     compileOnly 'org.codehaus.groovy:groovy-all:3.0.13'
     compileOnly 'org.apache.commons:commons-compress:1.23.0'
-    implementation('com.github.luben:zstd-jni:1.5.5-9')
+    implementation 'io.airlift:aircompressor:0.25'
 }
 
 intellij {

--- a/src/main/groovy/com/github/camork/extensions/ArchiveTreeProvider.groovy
+++ b/src/main/groovy/com/github/camork/extensions/ArchiveTreeProvider.groovy
@@ -10,6 +10,8 @@ import com.github.camork.filesystem.tar.TarFileSystem
 import com.github.camork.filesystem.tar.TarFileType
 import com.github.camork.filesystem.tar.TarGzFileType
 import com.github.camork.filesystem.zip.ZipFileSystem
+import com.github.camork.filesystem.zstd.ZstdFileSystem
+import com.github.camork.filesystem.zstd.ZstdFileType
 import com.github.camork.nodes.PsiDirectoryNodeWrapper
 import com.github.camork.util.CoreUtil
 import com.intellij.ide.highlighter.ArchiveFileType
@@ -85,6 +87,9 @@ class ArchiveTreeProvider implements TreeStructureProvider {
                         break
                     case SevenZipFileType.INSTANCE:
                         archiveFile = SevenZipFileSystem.getInstance().getRootByLocal(treeNodeFile)
+                        break
+                    case ZstdFileType.INSTANCE:
+                        archiveFile = ZstdFileSystem.getInstance().getRootByLocal(treeNodeFile)
                         break
                 }
 

--- a/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFile.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFile.groovy
@@ -3,7 +3,7 @@ package com.github.camork.filesystem.zstd
 import com.github.camork.filesystem.IArchiveFile
 import com.github.camork.util.ArchiveUtils
 import com.github.camork.util.EntryInfo
-import com.github.luben.zstd.ZstdInputStream
+import io.airlift.compress.zstd.ZstdInputStream
 
 class ZstdFile implements IArchiveFile {
     private final File file

--- a/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFile.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFile.groovy
@@ -1,0 +1,40 @@
+package com.github.camork.filesystem.zstd
+
+import com.github.camork.filesystem.IArchiveFile
+import com.github.camork.util.ArchiveUtils
+import com.github.camork.util.EntryInfo
+import com.github.luben.zstd.ZstdInputStream
+
+class ZstdFile implements IArchiveFile {
+    private final File file
+    private ZstdInputStream zstdInputStream
+
+    ZstdFile(File file) {
+        this.file = file
+    }
+
+    @Override
+    Map<String, ?> createEntriesInfoMap() {
+        Map entries = new HashMap<String, ?>()
+        EntryInfo root = ArchiveUtils.createRootEntry()
+        entries.put('', root)
+        entries.put('contents', new EntryInfo('contents', false, file.length(), file.lastModified(), root))
+
+        return entries
+    }
+
+    @Override
+    byte[] getEntryBytes(String relativePath) {
+        return getInputStream().withCloseable { it.bytes }
+    }
+
+    @Override
+    InputStream getInputStream() {
+        return zstdInputStream = new ZstdInputStream(file.newInputStream())
+    }
+
+    @Override
+    void close() {
+        zstdInputStream?.close()
+    }
+}

--- a/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFileHandler.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFileHandler.groovy
@@ -1,0 +1,37 @@
+package com.github.camork.filesystem.zstd
+
+import com.github.camork.filesystem.ArchiveHandlerBase
+import com.intellij.util.io.FileAccessorCache
+import org.jetbrains.annotations.NotNull
+
+class ZstdFileHandler extends ArchiveHandlerBase<ZstdFile> {
+
+    ZstdFileHandler(@NotNull String path) {
+        super(path)
+    }
+
+    @Override
+    FileAccessorCache<ZstdFileHandler, ZstdFile> getFileAccessor() {
+        fileAccessor
+    }
+
+    private static final FileAccessorCache<ZstdFileHandler, ZstdFile> fileAccessor =
+            new FileAccessorCache<ZstdFileHandler, ZstdFile>(20, 10) {
+
+            @Override
+            protected ZstdFile createAccessor(ZstdFileHandler key) throws IOException {
+                setFileAttributes(key, key.canonicalPath)
+                return new ZstdFile(key.file.canonicalFile)
+            }
+
+            @Override
+            boolean isEqual(ZstdFileHandler val1, ZstdFileHandler val2) {
+                return val1 == val2
+            }
+
+            @Override
+            protected void disposeAccessor(@NotNull ZstdFile fileAccessor) throws IOException {
+                fileAccessor.close()
+            }
+        }
+}

--- a/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFileSystem.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFileSystem.groovy
@@ -1,0 +1,36 @@
+package com.github.camork.filesystem.zstd
+
+import com.github.camork.filesystem.ArchiveBasedFileSystem
+import com.github.camork.filesystem.gz.GZFileHandler
+import com.github.camork.filesystem.tar.TarGzFileType
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeRegistry
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.impl.ArchiveHandler
+import com.intellij.openapi.vfs.newvfs.VfsImplUtil
+import org.jetbrains.annotations.NotNull
+
+class ZstdFileSystem extends ArchiveBasedFileSystem {
+    public static final String PROTOCOL = 'zst'
+
+    static ZstdFileSystem getInstance() {
+        return VirtualFileManager.getInstance().getFileSystem(PROTOCOL) as ZstdFileSystem
+    }
+
+    @Override
+    String getProtocol() {
+        return PROTOCOL
+    }
+
+    @Override
+    protected ArchiveHandler getHandler(@NotNull VirtualFile entryFile) {
+        return VfsImplUtil.getHandler(this, entryFile, { path -> new ZstdFileHandler(path) })
+    }
+
+    @Override
+    protected boolean isCorrectFileType(@NotNull VirtualFile local) {
+        FileType fileType = FileTypeRegistry.getInstance().getFileTypeByFileName(local.name)
+        return fileType == ZstdFileType.INSTANCE
+    }
+}

--- a/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFileType.groovy
+++ b/src/main/groovy/com/github/camork/filesystem/zstd/ZstdFileType.groovy
@@ -1,0 +1,19 @@
+package com.github.camork.filesystem.zstd
+
+import com.github.camork.filesystem.ArchiveBasedFileType
+import com.intellij.openapi.fileTypes.FileType
+
+class ZstdFileType extends ArchiveBasedFileType {
+
+    public static final FileType INSTANCE = new ZstdFileType()
+
+    @Override
+    String getName() {
+        return 'ZSTANDARD'
+    }
+
+    @Override
+    String getDefaultExtension() {
+        return 'zst'
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -60,10 +60,13 @@
 				  fieldName="INSTANCE"/>
 		<fileType name="7ZIP" extensions="7z"
 				  implementationClass="com.github.camork.filesystem.sevenzip.SevenZipFileType" fieldName="INSTANCE"/>
+		<fileType name="ZSTANDARD" extensions="zst" implementationClass="com.github.camork.filesystem.zstd.ZstdFileType"
+				  fieldName="INSTANCE"/>
 		<virtualFileSystem key="gzip" implementationClass="com.github.camork.filesystem.gz.GZFileSystemImpl"/>
 		<virtualFileSystem key="tar" implementationClass="com.github.camork.filesystem.tar.TarFileSystemImpl"/>
 		<virtualFileSystem key="7z" implementationClass="com.github.camork.filesystem.sevenzip.SevenZipFileSystemImpl"/>
 		<virtualFileSystem key="zip" implementationClass="com.github.camork.filesystem.zip.ZipFileSystemImpl"/>
+		<virtualFileSystem key="zst" implementationClass="com.github.camork.filesystem.zstd.ZstdFileSystem"/>
 	</extensions>
 
 </idea-plugin>


### PR DESCRIPTION
The following changes are for a new feature request to support viewing (zstd)[https://facebook.github.io/zstd/] compressed files. I took an initial stab at the implementation for this. I'm new to Groovy but it seemed simple enough following the implementation for existing file types.

There is one caveat: accepting this PR does add a new dependency to the project (https://github.com/luben/zstd-jni).